### PR TITLE
exec,cl: simplify load/store field use reflect.type and []index (#550)

### DIFF
--- a/cl/context.go
+++ b/cl/context.go
@@ -185,16 +185,16 @@ func checkLabel(fl *flowLabel) bool {
 type blockCtx struct {
 	*pkgCtx
 	*funcCtx
-	file           *fileCtx
-	parent         *blockCtx
-	syms           map[string]iSymbol
-	noExecCtx      bool
-	takeAddr       bool
-	checkFlag      bool
-	checkArrayAddr bool
-	fieldVar       interface{}
-	fieldIndex     []int
-	fieldExprX     func()
+	file            *fileCtx
+	parent          *blockCtx
+	syms            map[string]iSymbol
+	noExecCtx       bool
+	takeAddr        bool
+	checkFlag       bool
+	checkLoadAddr   bool
+	fieldStructType reflect.Type
+	fieldIndex      []int
+	fieldExprX      func()
 }
 
 // function block ctx
@@ -235,10 +235,10 @@ func newGblBlockCtx(pkg *pkgCtx) *blockCtx {
 	}
 }
 
-func (p *blockCtx) resetFieldVar(v interface{}) {
-	p.fieldVar = v
-	p.fieldIndex = nil
-	p.fieldExprX = nil
+func (ctx *blockCtx) resetFieldIndex() {
+	ctx.fieldStructType = nil
+	ctx.fieldIndex = nil
+	ctx.fieldExprX = nil
 }
 
 func (p *blockCtx) requireLabel(name string) exec.Label {

--- a/cl/gopkg_test.go
+++ b/cl/gopkg_test.go
@@ -642,6 +642,8 @@ import (
 	pkg.Info.V5[0] = -100
 	println("pkg.Info.V5", pkg.Info.V5)
 	println("pkg.Info.V11[0]",pkg.Info.V11[0])
+	pkg.Info.V7[0] = "hello"
+	println("pkg.Info.V7[0]",pkg.Info.V7[0])
 	pkg.Info.V11[0] = nil
 	println("pkg.Info.V11",pkg.Info.V11)
 	pkg.Info.V11[1].Min.X = -101
@@ -694,4 +696,55 @@ import (
 	if info.V13[0] != nil || info.V13[1].Min.X != -105 || info.V13[1].Max.Y != -102 {
 		t.Fatal("V13", info.V13[0], info.V13[1])
 	}
+}
+
+func TestPkgFieldBadSet(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatalf("must panic")
+		} else {
+			t.Log("panic info", r)
+		}
+	}()
+
+	var I = exec.NewGoPackage("pkg_test_field_bad")
+
+	I.RegisterFuncs(
+		I.Func("NewRect", tNewRect, execTestNewRect),
+		I.Func("NewPoint", tNewPoint, execTestNewPoint),
+		I.Func("MakeRect", tMakeRect, execTestMakeRect),
+		I.Func("MakePoint", tMakePoint, execTestMakePoint),
+	)
+
+	var testSource string
+	testSource = `package main
+
+import (
+	pkg "pkg_test_field_bad"
+)
+
+pkg.MakeRect(10,20,100,200).Min.X = 10
+
+`
+	fsTestPkgVar := asttest.NewSingleFileFS("/foo", "bar.gop", testSource)
+	t.Log(testSource)
+
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseFSDir(fset, fsTestPkgVar, "/foo", nil, 0)
+	if err != nil || len(pkgs) != 1 {
+		t.Fatal("ParseFSDir failed:", err, len(pkgs))
+	}
+
+	bar := pkgs["main"]
+	b := exec.NewBuilder(nil)
+	_, _, err = newPackage(b, bar, fset)
+	if err != nil {
+		t.Fatal("Compile failed:", err)
+	}
+	code := b.Resolve()
+	code.Dump(os.Stdout)
+
+	ctx := exec.NewContext(code)
+	ctx.Exec(0, code.Len())
 }

--- a/cl/stmt.go
+++ b/cl/stmt.go
@@ -51,7 +51,6 @@ func compileBodyWith(ctx *blockCtx, body []ast.Stmt) {
 }
 
 func compileStmt(ctx *blockCtx, stmt ast.Stmt) {
-	ctx.resetFieldVar(nil)
 	start := ctx.out.StartStmt(stmt)
 	switch v := stmt.(type) {
 	case *ast.ExprStmt:

--- a/exec.spec/interface.go
+++ b/exec.spec/interface.go
@@ -306,13 +306,13 @@ type Builder interface {
 	AddrGoVar(addr GoVarAddr) Builder
 
 	// LoadField instr
-	LoadField(v interface{}, index []int) Builder
+	LoadField(typ reflect.Type, index []int) Builder
 
 	// StoreField instr
-	StoreField(v interface{}, index []int) Builder
+	StoreField(typ reflect.Type, index []int) Builder
 
 	// AddrField instr
-	AddrField(v interface{}, index []int) Builder
+	AddrField(typ reflect.Type, index []int) Builder
 
 	// AddrOp instr
 	AddrOp(kind Kind, op AddrOperator) Builder

--- a/exec/bytecode/gopkg.go
+++ b/exec/bytecode/gopkg.go
@@ -427,14 +427,7 @@ func (p *Builder) AddrGoVar(addr GoVarAddr) *Builder {
 }
 
 // LoadField instr
-func (p *Builder) LoadField(v interface{}, index []int) *Builder {
-	switch x := v.(type) {
-	case exec.GoVarAddr:
-		p.LoadGoVar(x)
-	case *Var:
-		p.LoadVar(x)
-	case reflect.Type:
-	}
+func (p *Builder) LoadField(typ reflect.Type, index []int) *Builder {
 	p.Push(index)
 	i := uint32(opLoadField << bitsOpShift)
 	p.code.data = append(p.code.data, uint32(i))
@@ -442,14 +435,7 @@ func (p *Builder) LoadField(v interface{}, index []int) *Builder {
 }
 
 // AddrField instr
-func (p *Builder) AddrField(v interface{}, index []int) *Builder {
-	switch x := v.(type) {
-	case exec.GoVarAddr:
-		p.AddrGoVar(x)
-	case *Var:
-		p.AddrVar(x)
-	case reflect.Type:
-	}
+func (p *Builder) AddrField(typ reflect.Type, index []int) *Builder {
 	p.Push(index)
 	i := uint32(opAddrField << bitsOpShift)
 	p.code.data = append(p.code.data, uint32(i))
@@ -457,14 +443,7 @@ func (p *Builder) AddrField(v interface{}, index []int) *Builder {
 }
 
 // StoreField instr
-func (p *Builder) StoreField(v interface{}, index []int) *Builder {
-	switch x := v.(type) {
-	case exec.GoVarAddr:
-		p.AddrGoVar(x)
-	case *Var:
-		p.AddrVar(x)
-	case reflect.Type:
-	}
+func (p *Builder) StoreField(typ reflect.Type, index []int) *Builder {
 	p.Push(index)
 	i := uint32(opStoreField << bitsOpShift)
 	p.code.data = append(p.code.data, uint32(i))

--- a/exec/bytecode/interface.go
+++ b/exec/bytecode/interface.go
@@ -325,20 +325,20 @@ func (p *iBuilder) AddrGoVar(addr GoVarAddr) exec.Builder {
 }
 
 // LoadField instr
-func (p *iBuilder) LoadField(v interface{}, index []int) exec.Builder {
-	((*Builder)(p)).LoadField(v, index)
+func (p *iBuilder) LoadField(typ reflect.Type, index []int) exec.Builder {
+	((*Builder)(p)).LoadField(typ, index)
 	return p
 }
 
 // AddrField instr
-func (p *iBuilder) AddrField(v interface{}, index []int) exec.Builder {
-	((*Builder)(p)).AddrField(v, index)
+func (p *iBuilder) AddrField(typ reflect.Type, index []int) exec.Builder {
+	((*Builder)(p)).AddrField(typ, index)
 	return p
 }
 
 // StoreField instr
-func (p *iBuilder) StoreField(v interface{}, index []int) exec.Builder {
-	((*Builder)(p)).StoreField(v, index)
+func (p *iBuilder) StoreField(typ reflect.Type, index []int) exec.Builder {
+	((*Builder)(p)).StoreField(typ, index)
 	return p
 }
 

--- a/exec/golang/builder_test.go
+++ b/exec/golang/builder_test.go
@@ -211,17 +211,17 @@ var y golang.testRect
 
 func main() {
 	y = pkg_field.Rect2
-	pkg_field.Rect.Info = "hello"
-	pkg_field.Rect.Pt1.X = -1
-	pkg_field.Rect.Pt2.Y = -2
-	y.Info = "world"
-	y.Pt1.X = -10
-	y.Pt2.Y = -20
+	(&pkg_field.Rect).Info = "hello"
+	(&pkg_field.Rect).Pt1.X = -1
+	(&pkg_field.Rect).Pt2.Y = -2
+	(&y).Info = "world"
+	(&y).Pt1.X = -10
+	(&y).Pt2.Y = -20
 	pkg_field.GetRect().Info = "next"
 	pkg_field.GetRect().Pt1.X = 101
 	pkg_field.GetRect().Pt2.Y = 102
 	pkg_field.Rect2 = y
-	fmt.Println(pkg_field.Rect.Info, pkg_field.Rect.Pt2.Y, y.Info, y.Pt2.Y, pkg_field.GetRect().Info, pkg_field.GetRect().Pt2.Y, &pkg_field.Rect.Pt1, &y.Pt1, &pkg_field.GetRect().Pt1)
+	fmt.Println(pkg_field.Rect.Info, pkg_field.Rect.Pt2.Y, y.Info, y.Pt2.Y, pkg_field.GetRect().Info, pkg_field.GetRect().Pt2.Y, &(&pkg_field.Rect).Pt1, &(&y).Pt1, &pkg_field.GetRect().Pt1)
 }
 `
 	println, _ := I.FindFuncv("println")
@@ -248,6 +248,8 @@ func main() {
 	if !ok {
 		t.Fatal("FindVar failed:", x)
 	}
+	xtyp := reflect.TypeOf(rc)
+
 	x2, ok := pkg.FindVar("Rect2")
 	if !ok {
 		t.Fatal("FindVar failed:", x2)
@@ -257,11 +259,9 @@ func main() {
 		t.Fatal("FindFunc failed:", fnTestRect)
 	}
 
-	it := reflect.TypeOf(rc)
-	it2 := reflect.TypeOf(gRect)
-
-	y := NewVar(it, "y")
-
+	gtyp := reflect.TypeOf(gRect)
+	ytyp := reflect.TypeOf(rc)
+	y := NewVar(ytyp, "y")
 	b := NewBuilder("main", nil, nil)
 
 	code := b.Interface().
@@ -271,57 +271,69 @@ func main() {
 		StoreVar(y). // y = pkg_field.Rect2
 		EndStmt(nil, &stmtState{rhsBase: 0}).
 		Push("hello").
-		StoreField(x, []int{0, 0}). // pkg_field.Rect.Info = "hello"
+		AddrGoVar(x).
+		StoreField(xtyp, []int{0, 0}). // pkg_field.Rect.Info = "hello"
 		EndStmt(nil, &stmtState{rhsBase: 0}).
 		Push(-1).
-		StoreField(x, []int{1, 0}). // pkg_field.Rect.Pt1.X = -1
+		AddrGoVar(x).
+		StoreField(xtyp, []int{1, 0}). // pkg_field.Rect.Pt1.X = -1
 		EndStmt(nil, &stmtState{rhsBase: 0}).
 		Push(-2).
-		StoreField(x, []int{2, 1}). // pkg_field.Rect.Pt2.Y = -2
+		AddrGoVar(x).
+		StoreField(xtyp, []int{2, 1}). // pkg_field.Rect.Pt2.Y = -2
 		EndStmt(nil, &stmtState{rhsBase: 0}).
 		Push("world").
-		StoreField(y, []int{0, 0}). // y.Info = "world"
+		AddrVar(y).
+		StoreField(ytyp, []int{0, 0}). // y.Info = "world"
 		EndStmt(nil, &stmtState{rhsBase: 0}).
 		Push(-10).
-		StoreField(y, []int{1, 0}). // y.Pt1.X = -10
+		AddrVar(y).
+		StoreField(ytyp, []int{1, 0}). // y.Pt1.X = -10
 		EndStmt(nil, &stmtState{rhsBase: 0}).
 		Push(-20).
-		StoreField(y, []int{2, 1}). // y.Pt2.Y = -20
+		AddrVar(y).
+		StoreField(ytyp, []int{2, 1}). // y.Pt2.Y = -20
 		EndStmt(nil, &stmtState{rhsBase: 0}).
 		Push("next").
 		CallGoFunc(fnTestRect, 0).
-		StoreField(it2, []int{0, 0}). // pkg_field.GetRect().Info = "next"
+		StoreField(gtyp, []int{0, 0}). // pkg_field.GetRect().Info = "next"
 		EndStmt(nil, &stmtState{rhsBase: 0}).
 		Push(101).
 		CallGoFunc(fnTestRect, 0).
-		StoreField(it2, []int{1, 0}). // pkg_field.GetRect().Pt1.X = 101
+		StoreField(gtyp, []int{1, 0}). // pkg_field.GetRect().Pt1.X = 101
 		EndStmt(nil, &stmtState{rhsBase: 0}).
 		Push(102).
 		CallGoFunc(fnTestRect, 0).
-		StoreField(it2, []int{2, 1}). // pkg_field.GetRect().Pt2.Y = 102
+		StoreField(gtyp, []int{2, 1}). // pkg_field.GetRect().Pt2.Y = 102
 		EndStmt(nil, &stmtState{rhsBase: 0}).
 		LoadVar(y).
 		StoreGoVar(x2). // pkg_field.Rect2 = y
 		EndStmt(nil, &stmtState{rhsBase: 0}).
-		LoadField(x, []int{0, 0}).
-		LoadField(x, []int{2, 1}).
-		LoadField(y, []int{0, 0}).
-		LoadField(y, []int{2, 1}).
+		LoadGoVar(x).
+		LoadField(xtyp, []int{0, 0}).
+		LoadGoVar(x).
+		LoadField(xtyp, []int{2, 1}).
+		LoadVar(y).
+		LoadField(ytyp, []int{0, 0}).
+		LoadVar(y).
+		LoadField(ytyp, []int{2, 1}).
 		CallGoFunc(fnTestRect, 0).
-		LoadField(it2, []int{0, 0}).
+		LoadField(gtyp, []int{0, 0}).
 		CallGoFunc(fnTestRect, 0).
-		LoadField(it2, []int{2, 1}).
-		AddrField(x, []int{1}).
-		AddrField(y, []int{1}).
+		LoadField(gtyp, []int{2, 1}).
+		AddrGoVar(x).
+		AddrField(xtyp, []int{1}).
+		AddrVar(y).
+		AddrField(ytyp, []int{1}).
 		CallGoFunc(fnTestRect, 0).
-		AddrField(it2, []int{1}).
+		AddrField(gtyp, []int{1}).
 		CallGoFuncv(println, 9, 9). // println(pkg_field.Rect.Info, pkg_field.Rect.Pt2.Y, y.Info, y.Pt2.Y, pkg_field.GetRect().Info, pkg_field.GetRect().Pt2.Y, &pkg_field.Rect.Pt1, &y.Pt1, &pkg_field.GetRect().Pt1)
 		EndStmt(nil, &stmtState{rhsBase: 0}).
 		Resolve()
 
 	if v := code.(*Code); v.String() != codeExp {
 		fmt.Println(v.String())
-		log.Fatal("TestGoVar failed: codeGen != codeExp")
+		t.Fatal("TestGoVar failed: codeGen != codeExp")
 	}
 }
 

--- a/exec/golang/expr.go
+++ b/exec/golang/expr.go
@@ -438,21 +438,9 @@ func (p *Builder) AddrGoVar(addr exec.GoVarAddr) *Builder {
 	return p
 }
 
-func (p *Builder) fieldExpr(v interface{}, index []int) ast.Expr {
-	var typ reflect.Type
+func (p *Builder) fieldExpr(typ reflect.Type, index []int) ast.Expr {
 	expr := &ast.SelectorExpr{}
-	switch x := v.(type) {
-	case exec.GoVarAddr:
-		gvi := defaultImpl.GetGoVarInfo(x)
-		typ = reflect.TypeOf(gvi.This).Elem()
-		expr.X = p.GoSymIdent(gvi.Pkg.PkgPath(), gvi.Name)
-	case exec.Var:
-		typ = x.Type()
-		expr.X = Ident(x.Name())
-	case reflect.Type:
-		typ = x
-		expr.X = p.rhs.Pop().(ast.Expr)
-	}
+	expr.X = p.rhs.Pop().(ast.Expr)
 	if typ.Kind() == reflect.Ptr {
 		typ = typ.Elem()
 	}
@@ -470,15 +458,15 @@ func (p *Builder) fieldExpr(v interface{}, index []int) ast.Expr {
 }
 
 // LoadField instr
-func (p *Builder) LoadField(v interface{}, index []int) *Builder {
-	expr := p.fieldExpr(v, index)
+func (p *Builder) LoadField(typ reflect.Type, index []int) *Builder {
+	expr := p.fieldExpr(typ, index)
 	p.rhs.Push(expr)
 	return p
 }
 
 // AddrField instr
-func (p *Builder) AddrField(v interface{}, index []int) *Builder {
-	expr := p.fieldExpr(v, index)
+func (p *Builder) AddrField(typ reflect.Type, index []int) *Builder {
+	expr := p.fieldExpr(typ, index)
 	p.rhs.Push(&ast.UnaryExpr{
 		Op: token.AND,
 		X:  expr,
@@ -487,8 +475,8 @@ func (p *Builder) AddrField(v interface{}, index []int) *Builder {
 }
 
 // StoreField instr
-func (p *Builder) StoreField(v interface{}, index []int) *Builder {
-	expr := p.fieldExpr(v, index)
+func (p *Builder) StoreField(typ reflect.Type, index []int) *Builder {
+	expr := p.fieldExpr(typ, index)
 	p.lhs.Push(expr)
 	return p
 }

--- a/exec/golang/interface.go
+++ b/exec/golang/interface.go
@@ -341,20 +341,20 @@ func (p *iBuilder) AddrGoVar(addr exec.GoVarAddr) exec.Builder {
 }
 
 // LoadField instr
-func (p *iBuilder) LoadField(v interface{}, index []int) exec.Builder {
-	((*Builder)(p)).LoadField(v, index)
+func (p *iBuilder) LoadField(typ reflect.Type, index []int) exec.Builder {
+	((*Builder)(p)).LoadField(typ, index)
 	return p
 }
 
 // AddrField instr
-func (p *iBuilder) AddrField(v interface{}, index []int) exec.Builder {
-	((*Builder)(p)).AddrField(v, index)
+func (p *iBuilder) AddrField(typ reflect.Type, index []int) exec.Builder {
+	((*Builder)(p)).AddrField(typ, index)
 	return p
 }
 
 // StoreField instr
-func (p *iBuilder) StoreField(v interface{}, index []int) exec.Builder {
-	((*Builder)(p)).StoreField(v, index)
+func (p *iBuilder) StoreField(typ reflect.Type, index []int) exec.Builder {
+	((*Builder)(p)).StoreField(typ, index)
 	return p
 }
 


### PR DESCRIPTION
* cl: fix fieldExprX check

* cl: TestPkgField

* cl: change fieldVar => fieldStructType

* exec: update LoadField/StoreField/AddrField api

* golang: fix test

* cl: add TestPkgFieldBadSet

* cl: fix index.field load/store

* cl: checkLoadAddr check kind!=slice and kind!=map

* bytecode: add test

* cl: simplify ctx.resetFieldIndex

* bytecode: TestArrayBadStoreField

* bytecode: TestSliceField

* bytecode: TestBadRegisterPkg